### PR TITLE
Fix number parsing for thousands separators

### DIFF
--- a/generate_summary.py
+++ b/generate_summary.py
@@ -45,9 +45,24 @@ def parse_number(value):
         # Remove spaces (thousands separator)
         value = value.replace(" ", "").replace("\u00a0", "")
 
+        # Handle mixed format with both separators (e.g., "1.200,5" or "1,200.5")
+        if '.' in value and ',' in value:
+            # Determine which is thousands and which is decimal by position
+            dot_pos = value.rfind('.')
+            comma_pos = value.rfind(',')
+            if dot_pos > comma_pos:
+                # Dot is decimal (e.g., "1,200.5" -> 1200.5)
+                value = value.replace(",", "")
+            else:
+                # Comma is decimal (e.g., "1.200,5" -> 1200.5)
+                value = value.replace(".", "").replace(",", ".")
+        # Check if dot is thousands separator (e.g., "5.972" = 5972)
+        # Dot followed by exactly 3 digits = thousands separator (Czech format)
+        elif re.match(r'^\d+\.\d{3}$', value):
+            value = value.replace(".", "")
         # Check if comma is thousands separator (e.g., "2,738" = 2738)
         # or decimal separator (e.g., "2,5" = 2.5)
-        if re.match(r'^\d+,\d{3}$', value):
+        elif re.match(r'^\d+,\d{3}$', value):
             # Comma followed by exactly 3 digits = thousands separator
             value = value.replace(",", "")
         else:

--- a/generate_summary.py
+++ b/generate_summary.py
@@ -56,14 +56,13 @@ def parse_number(value):
             else:
                 # Comma is decimal (e.g., "1.200,5" -> 1200.5)
                 value = value.replace(".", "").replace(",", ".")
-        # Check if dot is thousands separator (e.g., "5.972" = 5972)
-        # Dot followed by exactly 3 digits = thousands separator (Czech format)
-        elif re.match(r'^\d+\.\d{3}$', value):
+        # Check if dot is thousands separator (e.g., "5.972" or "1.234.567")
+        # Pattern: 1-3 digits followed by groups of dot + 3 digits (Czech format)
+        elif re.match(r'^\d{1,3}(\.\d{3})+$', value):
             value = value.replace(".", "")
-        # Check if comma is thousands separator (e.g., "2,738" = 2738)
-        # or decimal separator (e.g., "2,5" = 2.5)
-        elif re.match(r'^\d+,\d{3}$', value):
-            # Comma followed by exactly 3 digits = thousands separator
+        # Check if comma is thousands separator (e.g., "2,738" or "1,234,567")
+        # Pattern: 1-3 digits followed by groups of comma + 3 digits
+        elif re.match(r'^\d{1,3}(,\d{3})+$', value):
             value = value.replace(",", "")
         else:
             # Otherwise treat comma as decimal separator


### PR DESCRIPTION
## Summary
- Fixes `parse_number()` to correctly handle dot as thousands separator (Czech format)
- Adds support for mixed formats with both separators (e.g., `1.200,5`)
- Steps are now correctly counted (1,162,534 instead of 1,162)

## Changes
| Format | Example | Result |
|--------|---------|--------|
| CZ thousands | `5.972` | 5972 |
| EN thousands | `2,738` | 2738 |
| CZ mixed | `1.200,5` | 1200.5 |
| EN mixed | `1,200.5` | 1200.5 |

Fixes #2